### PR TITLE
Feat. 회원가입 및 로그인 기능 구현

### DIFF
--- a/scheduler/src/main/java/lavi/scheduler/controller/KakaoLoginController.java
+++ b/scheduler/src/main/java/lavi/scheduler/controller/KakaoLoginController.java
@@ -1,8 +1,11 @@
 package lavi.scheduler.controller;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpSession;
 import lavi.scheduler.domain.KakaoInfo;
 import lavi.scheduler.domain.OAuthToken;
+import lavi.scheduler.domain.UserSession;
 import lavi.scheduler.service.KakaoLoginService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -30,7 +33,7 @@ public class KakaoLoginController {
     }
 
     @GetMapping("/login/kakao/oauth")
-    public void kakaoLogin(@RequestParam String code) throws JsonProcessingException {
+    public String kakaoLogin(@RequestParam String code, HttpServletRequest httpServletRequest) throws JsonProcessingException {
 
         //2. 토큰 받기
         log.info("[*]   토큰 받기");
@@ -42,13 +45,24 @@ public class KakaoLoginController {
         KakaoInfo userInfo = kakaoLoginService.getUserInfo(accessToken);
 
         //4. 사용자 정보의 id 이용해서 회원인지 아닌지 검증
-        boolean isMember = kakaoLoginService.isMember(userInfo.getId());
-        if (isMember) {
-            //회원이면 로그인 성공 화면으로 이동
-            log.info("[*]   로그인 성공!");
+        UserSession userSession = kakaoLoginService.isMember(userInfo.getId());
+        if (userSession == null) {
+            //회원이 아니면 회원가입 화면으로 이동(카카오 회원번호 같이 넘김)
+            log.info("[*]   로그인 실패! 카카오 회원번호 전송 = {}", userInfo.getId());
+
+            HttpSession httpSession = httpServletRequest.getSession();
+            httpSession.setAttribute("kakaoId", userInfo.getId());
+
+            return "redirect:/join";
         } else {
-            //회원이 아니면 회원가입 화면으로 이동(이 때 카카오 id client 로 넘겨서 회원가입할 때 포함해서 Member 객체 생성해야함)
-            log.info("[*]   로그인 실패!");
+            //회원이면 홈 화면으로 이동
+            log.info("[*]   로그인 성공!");
+
+            //세션 생성
+            HttpSession httpSession = httpServletRequest.getSession();
+            httpSession.setAttribute("userSession", userSession);
+
+            return "redirect:/";
         }
 
     }

--- a/scheduler/src/main/java/lavi/scheduler/domain/KakaoInfo.java
+++ b/scheduler/src/main/java/lavi/scheduler/domain/KakaoInfo.java
@@ -10,12 +10,12 @@ import java.time.LocalDateTime;
 @JsonIgnoreProperties({"kakao_account"})
 @Getter
 public class KakaoInfo {
-    private Long id;
+    private String id;
     private LocalDateTime connectedAt;
     private Properties properties;
 
     @JsonCreator
-    public KakaoInfo(@JsonProperty("id") Long id,
+    public KakaoInfo(@JsonProperty("id") String id,
                      @JsonProperty("connected_at") LocalDateTime connectedAt,
                      @JsonProperty("properties") Properties properties) {
         this.id = id;

--- a/scheduler/src/main/java/lavi/scheduler/domain/Member.java
+++ b/scheduler/src/main/java/lavi/scheduler/domain/Member.java
@@ -1,17 +1,16 @@
 package lavi.scheduler.domain;
 
 import jakarta.persistence.*;
-import lombok.AllArgsConstructor;
 import lombok.Getter;
 
 @Entity
 @Getter
-@AllArgsConstructor
 public class Member {
 
-    @Id
+    @Id @GeneratedValue
     @Column( name = "member_id")
     private Long id;
+    private String kakaoId;
     private String name;
     private String eMail;
     private int pay;
@@ -19,6 +18,15 @@ public class Member {
 
     @Enumerated(EnumType.STRING)
     private RollType rollType;
+
+    public Member(String kakaoId, String name, String eMail, String gender) {
+        this.kakaoId = kakaoId;
+        this.name = name;
+        this.eMail = eMail;
+        this.pay = 10000;
+        this.gender = gender;
+        this.rollType = RollType.User;
+    }
 
     public Member() {
 

--- a/scheduler/src/main/java/lavi/scheduler/domain/UserSession.java
+++ b/scheduler/src/main/java/lavi/scheduler/domain/UserSession.java
@@ -1,0 +1,12 @@
+package lavi.scheduler.domain;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@AllArgsConstructor
+@Getter
+public class UserSession {
+    private Long id;
+    private String name;
+    private RollType rollType;
+}

--- a/scheduler/src/main/java/lavi/scheduler/repository/MemberRepository.java
+++ b/scheduler/src/main/java/lavi/scheduler/repository/MemberRepository.java
@@ -4,4 +4,5 @@ import lavi.scheduler.domain.Member;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface MemberRepository extends JpaRepository<Member, Long> {
+    Member findByKakaoId(String id);
 }

--- a/scheduler/src/main/java/lavi/scheduler/service/KakaoLoginService.java
+++ b/scheduler/src/main/java/lavi/scheduler/service/KakaoLoginService.java
@@ -3,7 +3,9 @@ package lavi.scheduler.service;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import lavi.scheduler.domain.KakaoInfo;
+import lavi.scheduler.domain.Member;
 import lavi.scheduler.domain.OAuthToken;
+import lavi.scheduler.domain.UserSession;
 import lavi.scheduler.repository.MemberRepository;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
@@ -85,8 +87,13 @@ public class KakaoLoginService {
         return rt.exchange(urlStr, HttpMethod.GET, userInfoRequest, KakaoInfo.class).getBody();
     }
 
-    public boolean isMember(Long id) {
+    public UserSession isMember(String id) {
         log.info("[*]   데이터베이스에서 카카오 고유 id와 일치하는 값이 있는지 검증");
-        return memberRepository.existsById(id);
+        Member member = memberRepository.findByKakaoId(id);
+        if (member == null) {
+            return null;
+        } else {
+            return new UserSession(member.getId(), member.getName(), member.getRollType());
+        }
     }
 }


### PR DESCRIPTION
[수정]
- 기존 Member 테이블에 기본키를 별도로 생성 (추후에 일반 로그인 또는 다른 소셜 로그인을 고려)
- Long 타입으로 받던 카카오 회원번호를 String 타입으로 수정

[추가]
- 회원이 아닌 경우 Session에 카카오 회원번호 담아서 /join으로 리다이렉트
- 회원인 경우 Session에 member_id, name, rollType 이 담긴 userSession 객체 생성 후 저장과 함께 / 로 리다이렉트